### PR TITLE
Added support for project name

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -107,6 +107,8 @@ export class WakaTime {
                 let core = this.dependencies.getCoreLocation();
                 let user_agent = 'vscode/' + vscode.version + ' vscode-wakatime/' + this.extension.version;
                 let args = [core, '--file', file, '--plugin', user_agent];
+                if (!!vscode.workspace && !!vscode.workspace.rootPath)
+                    args.push('--project', vscode.workspace.rootPath.match(/([^\/^\\]*)[\/\\]*$/)[1]);
                 if (isWrite)
                     args.push('--write');
         


### PR DESCRIPTION
Thanks for this WakaTime extension. However, I felt like it was missing the project name - my VSC projects would always be reported as "Unknown Project".

With this small change, the plugin now also reports the `--project` name to the command line interface. The project name is inferred from the workspace -- that is, the current folder name is used. This is consistent with the workspace name VSCode shows in its title window.

In other words, this box in WakaTime's dashboard...

![image](https://cloud.githubusercontent.com/assets/49529/16060637/cc6d9d30-3256-11e6-9ab0-d22baff8ebca.png)

...now becomes this:

![image](https://cloud.githubusercontent.com/assets/49529/16060647/dcc905f2-3256-11e6-9894-4ce852579498.png)

Your project names, however, may vary.