### PR TITLE
prefer python3 over installed python2 on osx

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -459,8 +459,8 @@ class Dependencies {
 
     let locations: string[] = [
       this.dirname + path.sep + 'python' + path.sep + 'pythonw',
-      'pythonw',
       'python3',
+      'pythonw',
       'python',
       '/usr/local/bin/python3',
       '/usr/local/bin/python',


### PR DESCRIPTION
For some reason python2 on my osx was giving ssl error for vscode-wakatime plugin but it was working perfectly fine for atom-wakatime. So I looked at what was different and reason was atom-wakatime was using python3 but vscode-wakatime was using python2. So i changed preference order for vscode-wakatime. 