### PR TITLE
Separate plugins and use --plugin for each

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -272,9 +272,10 @@ export class WakaTime {
         this.dependencies.getPythonLocation(pythonBinary => {
           if (pythonBinary) {
             let core = this.dependencies.getCoreLocation();
-            let user_agent =
-              this.agentName + '/' + vscode.version + ' vscode-wakatime/' + this.extension.version;
-            let args = [core, '--file', file, '--plugin', user_agent];
+            let vscode_agent =
+              this.agentName + '/' + vscode.version;
+            let extension_agent = ' vscode-wakatime/' + this.extension.version;
+            let args = [core, '--file', file, '--plugin', vscode_agent, '--plugin', extension_agent];
             let project = this.getProjectName(file);
             if (project) args.push('--alternate-project', project);
             if (isWrite) args.push('--write');


### PR DESCRIPTION
This PR introduces a fix for extension running `wakatime` with failed argument placement (see #69 ).

Fixes #69 