### PR TITLE
Quote user agent

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -272,9 +272,9 @@ export class WakaTime {
         this.dependencies.getPythonLocation(pythonBinary => {
           if (pythonBinary) {
             let core = this.dependencies.getCoreLocation();
-            let user_agent =
+            let user_agent = 
               this.agentName + '/' + vscode.version + ' vscode-wakatime/' + this.extension.version;
-            let args = [core, '--file', file, '--plugin', user_agent];
+            let args = [core, '--file', file, '--plugin', '"' + user_agent + '"'];
             let project = this.getProjectName(file);
             if (project) args.push('--alternate-project', project);
             if (isWrite) args.push('--write');


### PR DESCRIPTION
This PR introduces quotations for `--plugin` argument values as they are delimited by a space and thus are interpretted as different argument.

Fixes #69 