### PR TITLE
Issue 141: Add disabled option to config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 dist
 out/**
 node_modules
+wakatime-cli
 .vscode-test/**
 *.vsix
 npm-debug.log*

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,22 +7,31 @@
 			"type": "extensionHost",
 			"request": "launch",
 			"runtimeExecutable": "${execPath}",
-			"args": ["--extensionDevelopmentPath=${workspaceFolder}" ],
+			"args": [
+				"--extensionDevelopmentPath=${workspaceFolder}"
+			],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outFiles": ["${workspaceFolder}/out/**/*.js"],
-			"preLaunchTask": "npm: watch"
+			"outFiles": [
+				"${workspaceFolder}/out/**/*.js"
+			],
+			"preLaunchTask": "npm: compile"
 		},
 		{
 			"name": "Launch Tests",
 			"type": "extensionHost",
 			"request": "launch",
 			"runtimeExecutable": "${execPath}",
-			"args": ["--extensionDevelopmentPath=${workspaceFolder}", "--extensionTestsPath=${workspaceFolder}/out/test" ],
+			"args": [
+				"--extensionDevelopmentPath=${workspaceFolder}",
+				"--extensionTestsPath=${workspaceFolder}/out/test"
+			],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outFiles": ["${workspaceFolder}/out/test/**/*.js"],
-			"preLaunchTask": "npm: watch"
+			"outFiles": [
+				"${workspaceFolder}/out/test/**/*.js"
+			],
+			"preLaunchTask": "npm: compile"
 		}
 	]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 # Changelog
 
-## 4.0.1 (Unreleased)
+## 4.0.2 (Unreleased)
 
 - Add config option to disable extension.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 
 # Changelog
 
+## 4.0.1 (2020-07-11)
+
+- Add config option to disable extension.
 
 ## 4.0.0 (2020-02-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 # Changelog
 
-## 4.0.1 (2020-07-11)
+## 4.0.1 (Unreleased)
 
 - Add config option to disable extension.
 
@@ -460,4 +460,3 @@
 ## 0.0.1 (2015-11-16)
 
 - Birth
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 
 # Changelog
 
-## 4.0.2 (Unreleased)
+## 4.0.4 (Unreleased)
 
 - Add config option to disable extension.
+  [#141](https://github.com/wakatime/vscode-wakatime/issues/141)
 
 ## 4.0.3 (2020-08-22)
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ Extension settings are stored in the INI file at `$WAKATIME_HOME/.wakatime.cfg`.
 
 More information can be found from [wakatime core](https://github.com/wakatime/wakatime#configuring).
 
-Note: `$WAKATIME_HOME` defaults to `$HOME`
-
+Notes: 
+1. `$WAKATIME_HOME` defaults to `$HOME`
+1. To disable the extension at startup add `disabled=true` to your config 
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ More information can be found from [wakatime core](https://github.com/wakatime/w
 
 Notes: 
 1. `$WAKATIME_HOME` defaults to `$HOME`
-1. To disable the extension at startup add `disabled=true` to your config 
+1. To disable the extension at startup add `disabled=true` to your config, this operation can also be performed by pressing `⌘ + Shift + P` and selecting `WakaTime: Disable`.
 
 ## Troubleshooting
 

--- a/package.json
+++ b/package.json
@@ -66,6 +66,14 @@
         "title": "WakaTime: Debug"
       },
       {
+        "command": "wakatime.disable",
+        "title": "WakaTime: Disable via config (Reload required)"
+      },
+      {
+        "command": "wakatime.re_enable",
+        "title": "WakaTime: Re-enable via config if disabled (Reload required)"
+      },
+      {
         "command": "wakatime.status_bar_enabled",
         "title": "WakaTime: Status Bar Enabled"
       },

--- a/package.json
+++ b/package.json
@@ -67,11 +67,7 @@
       },
       {
         "command": "wakatime.disable",
-        "title": "WakaTime: Disable via config (Reload required)"
-      },
-      {
-        "command": "wakatime.re_enable",
-        "title": "WakaTime: Re-enable via config if disabled (Reload required)"
+        "title": "WakaTime: Disable/Enable Extension"
       },
       {
         "command": "wakatime.status_bar_enabled",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,11 +1,13 @@
 export const COMMAND_API_KEY = 'wakatime.apikey';
-export const COMMAND_PROXY = 'wakatime.proxy';
-export const COMMAND_DEBUG = 'wakatime.debug';
-export const COMMAND_STATUS_BAR_ENABLED = 'wakatime.status_bar_enabled';
-export const COMMAND_STATUS_BAR_CODING_ACTIVITY = 'wakatime.status_bar_coding_activity';
-export const COMMAND_DASHBOARD = 'wakatime.dashboard';
 export const COMMAND_CONFIG_FILE = 'wakatime.config_file';
+export const COMMAND_DASHBOARD = 'wakatime.dashboard';
+export const COMMAND_DEBUG = 'wakatime.debug';
+export const COMMAND_DISABLE = 'wakatime.disable';
+export const COMMAND_RE_ENABLE = 'wakatime.re_enable';
 export const COMMAND_LOG_FILE = 'wakatime.log_file';
+export const COMMAND_PROXY = 'wakatime.proxy';
+export const COMMAND_STATUS_BAR_CODING_ACTIVITY = 'wakatime.status_bar_coding_activity';
+export const COMMAND_STATUS_BAR_ENABLED = 'wakatime.status_bar_enabled';
 export enum LogLevel {
   DEBUG = 0,
   INFO,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,6 @@ export const COMMAND_CONFIG_FILE = 'wakatime.config_file';
 export const COMMAND_DASHBOARD = 'wakatime.dashboard';
 export const COMMAND_DEBUG = 'wakatime.debug';
 export const COMMAND_DISABLE = 'wakatime.disable';
-export const COMMAND_RE_ENABLE = 'wakatime.re_enable';
 export const COMMAND_LOG_FILE = 'wakatime.log_file';
 export const COMMAND_PROXY = 'wakatime.proxy';
 export const COMMAND_STATUS_BAR_CODING_ACTIVITY = 'wakatime.status_bar_coding_activity';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,6 @@ import {
   COMMAND_DASHBOARD,
   COMMAND_DEBUG,
   COMMAND_DISABLE,
-  COMMAND_RE_ENABLE,
   COMMAND_LOG_FILE,
   COMMAND_PROXY,
   COMMAND_STATUS_BAR_CODING_ACTIVITY,
@@ -24,12 +23,6 @@ export function activate(ctx: vscode.ExtensionContext) {
   var options = new Options();
   
   wakatime = new WakaTime(ctx.extensionPath, logger, options);
-
-  ctx.subscriptions.push(
-    vscode.commands.registerCommand(COMMAND_RE_ENABLE, function() {
-      wakatime.promptToReEnable();
-    }),
-  );
 
   ctx.subscriptions.push(
     vscode.commands.registerCommand(COMMAND_DISABLE, function() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,13 +2,15 @@ import * as vscode from 'vscode';
 
 import {
   COMMAND_API_KEY,
-  COMMAND_PROXY,
-  COMMAND_DEBUG,
-  COMMAND_STATUS_BAR_ENABLED,
-  COMMAND_STATUS_BAR_CODING_ACTIVITY,
-  COMMAND_DASHBOARD,
   COMMAND_CONFIG_FILE,
+  COMMAND_DASHBOARD,
+  COMMAND_DEBUG,
+  COMMAND_DISABLE,
+  COMMAND_RE_ENABLE,
   COMMAND_LOG_FILE,
+  COMMAND_PROXY,
+  COMMAND_STATUS_BAR_CODING_ACTIVITY,
+  COMMAND_STATUS_BAR_ENABLED,
   LogLevel,
 } from './constants';
 import { Logger } from './logger';
@@ -22,6 +24,18 @@ export function activate(ctx: vscode.ExtensionContext) {
   var options = new Options();
   
   wakatime = new WakaTime(ctx.extensionPath, logger, options);
+
+  ctx.subscriptions.push(
+    vscode.commands.registerCommand(COMMAND_RE_ENABLE, function() {
+      wakatime.promptToReEnable();
+    }),
+  );
+
+  ctx.subscriptions.push(
+    vscode.commands.registerCommand(COMMAND_DISABLE, function() {
+      wakatime.promptToDisable();
+    }),
+  );
 
   ctx.subscriptions.push(
     vscode.commands.registerCommand(COMMAND_API_KEY, function() {
@@ -80,10 +94,6 @@ export function activate(ctx: vscode.ExtensionContext) {
     }
     options.getSetting('settings', 'standalone', (_err, standalone) => {
       wakatime.initialize(standalone !== 'false');  
-
-      options.getSetting('settings', 'disabled', (_e, disabled) => {
-        if (disabled === 'true') deactivate();
-      });
     });
   });
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,7 +20,7 @@ var wakatime: WakaTime;
 
 export function activate(ctx: vscode.ExtensionContext) {
   var options = new Options();
-
+  
   wakatime = new WakaTime(ctx.extensionPath, logger, options);
 
   ctx.subscriptions.push(
@@ -79,7 +79,11 @@ export function activate(ctx: vscode.ExtensionContext) {
       logger.debug('::WakaTime debug mode::');
     }
     options.getSetting('settings', 'standalone', (_err, standalone) => {
-      wakatime.initialize(standalone !== 'false');
+      wakatime.initialize(standalone !== 'false');  
+
+      options.getSetting('settings', 'disabled', (_e, disabled) => {
+        if (disabled === 'true') deactivate();
+      });
     });
   });
 }

--- a/src/wakatime.ts
+++ b/src/wakatime.ts
@@ -83,22 +83,26 @@ export class WakaTime {
   }
 
   public promptForApiKey(): void {
-    this.options.getSetting('settings', 'api_key', (_err, defaultVal) => {
-      if (Libs.validateKey(defaultVal) != '') defaultVal = '';
-      let promptOptions = {
-        prompt: 'WakaTime Api Key',
-        placeHolder: 'Enter your api key from https://wakatime.com/settings',
-        value: defaultVal,
-        ignoreFocusOut: true,
-        validateInput: Libs.validateKey.bind(this),
-      };
-      vscode.window.showInputBox(promptOptions).then(val => {
-        if (val != undefined) {
-          let validation = Libs.validateKey(val);
-          if (validation === '') this.options.setSetting('settings', 'api_key', val);
-          else vscode.window.setStatusBarMessage(validation);
-        } else vscode.window.setStatusBarMessage('WakaTime api key not provided');
-      });
+    this.options.getSetting('settings', 'disabled', (_e, disabled) => {
+      if (disabled !== 'true'){
+        this.options.getSetting('settings', 'api_key', (_err, defaultVal) => {
+          if (Libs.validateKey(defaultVal) != '') defaultVal = '';
+          let promptOptions = {
+            prompt: 'WakaTime Api Key',
+            placeHolder: 'Enter your api key from https://wakatime.com/settings',
+            value: defaultVal,
+            ignoreFocusOut: true,
+            validateInput: Libs.validateKey.bind(this),
+          };
+          vscode.window.showInputBox(promptOptions).then(val => {
+            if (val != undefined) {
+              let validation = Libs.validateKey(val);
+              if (validation === '') this.options.setSetting('settings', 'api_key', val);
+              else vscode.window.setStatusBarMessage(validation);
+            } else vscode.window.setStatusBarMessage('WakaTime api key not provided');
+          });
+        });
+      }
     });
   }
 

--- a/src/wakatime.ts
+++ b/src/wakatime.ts
@@ -84,35 +84,29 @@ export class WakaTime {
     this.setupEventListeners();
   }
 
-  public promptToReEnable(): void {
-    this.options.getSetting('settings', 'disabled', (_err, defaultVal) => {
-      if (!defaultVal || defaultVal !== 'true') defaultVal = 'false';
-      let items: string[] = ['true', 'false'];
-      const helperText =  defaultVal === 'true' ? "disabled" : "enabled";
-      let promptOptions = {
-        placeHolder: `true or false (extension is currently "${helperText}\")`,
-        value: defaultVal,
-        ignoreFocusOut: true,
-      };
-      vscode.window.showQuickPick(items, promptOptions).then(newVal => {
-        if (newVal === 'true')this.options.setSetting('settings', 'disabled', 'false');
-      });
-    });
-
-  }
-
   public promptToDisable(): void {
-    this.options.getSetting('settings', 'disabled', (_err, defaultVal) => {
-      if (!defaultVal || defaultVal !== 'true') defaultVal = 'false';
-      let items: string[] = ['true', 'false'];
-      const helperText =  defaultVal === 'true' ? "disabled" : "enabled";
+    this.options.getSetting('settings', 'disabled', (_err, currentVal) => {
+      if (!currentVal || currentVal !== 'true') currentVal = 'false';
+      let items: string[] = ['disable', 'enable'];
+      const helperText =  currentVal === 'true' ? "disabled" : "enabled";
       let promptOptions = {
-        placeHolder: `true or false (extension is currently "${helperText}\")`,
-        value: defaultVal,
+        placeHolder: `disable or enable (extension is currently "${helperText}")`,
         ignoreFocusOut: true,
       };
       vscode.window.showQuickPick(items, promptOptions).then(newVal => {
-        if (newVal === 'true')this.options.setSetting('settings', 'disabled', 'true');
+        if (newVal === 'disable') {
+          this.options.setSetting('settings', 'disabled', 'true');
+          this.options.getSetting('settings', 'status_bar_enabled', (_err, currentValue) => {
+            if (!currentValue || currentValue === 'true')  this.updateStatusBar('false');
+          });
+          
+        };
+        if (newVal === 'enable') {
+          this.options.setSetting('settings', 'disabled', 'false');
+          this.options.getSetting('settings', 'status_bar_enabled', (_err, currentValue) => {
+            if (currentValue === 'false') this.updateStatusBar('true');
+          });
+        }
       });
     });
   }
@@ -184,20 +178,22 @@ export class WakaTime {
         value: defaultVal,
         ignoreFocusOut: true,
       };
-      vscode.window.showQuickPick(items, promptOptions).then(newVal => {
-        if (newVal == null) return;
-        this.options.setSetting('settings', 'status_bar_enabled', newVal);
-        if (newVal === 'true') {
-          this.showStatusBar = true;
-          this.statusBar.show();
-          this.logger.debug('Status bar icon enabled');
-        } else {
-          this.showStatusBar = false;
-          this.statusBar.hide();
-          this.logger.debug('Status bar icon disabled');
-        }
-      });
+      vscode.window.showQuickPick(items, promptOptions).then(newVal => this.updateStatusBar(newVal));
     });
+  }
+
+  private updateStatusBar = (newVal) => {
+    if (newVal == null) return;
+    this.options.setSetting('settings', 'status_bar_enabled', newVal);
+    if (newVal === 'true') {
+      this.showStatusBar = true;
+      this.statusBar.show();
+      this.logger.debug('Status bar icon enabled');
+    } else {
+      this.showStatusBar = false;
+      this.statusBar.hide();
+      this.logger.debug('Status bar icon disabled');
+    }
   }
 
   public promptStatusBarCodingActivity(): void {


### PR DESCRIPTION
Link to the original issue that I raised: https://github.com/wakatime/vscode-wakatime/issues/141. Which contains the reasoning for the change.

I tried to make the least invasive change possible. 

In order to test the changes you can add the `disabled=true` option to your `.wakatime.cfg`. That will dispose of the extension on startup. Otherwise there should be no change in behaviour.

Let me know what you guys think.

Thanks,
Matt