### PR TITLE
Prevent opening cmd window when sending heartbeats on Windows platform

### DIFF
--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -127,8 +127,11 @@ export class Dependencies {
     this.logger.debug(`Looking for python at: ${binary}`);
 
     const args = ['--version'];
+    const options = {
+      windowsHide: true,
+    };
     try {
-      child_process.execFile(binary, args, (error, stdout, stderr) => {
+      child_process.execFile(binary, args, options, (error, stdout, stderr) => {
         const output: string = stdout.toString() + stderr.toString();
         if (!error && this.isSupportedPythonVersion(binary, output)) {
           this.cachedPythonLocation = binary;
@@ -154,7 +157,10 @@ export class Dependencies {
     this.getPythonLocation(pythonBinary => {
       if (pythonBinary) {
         let args = [this.getCliLocation(), '--version'];
-        child_process.execFile(pythonBinary, args, (error, _stdout, stderr) => {
+        const options = {
+          windowsHide: true,
+        };
+        child_process.execFile(pythonBinary, args, options, (error, _stdout, stderr) => {
           if (!(error != null)) {
             let currentVersion = _stdout.toString().trim() + stderr.toString().trim();
             this.logger.debug(`Current wakatime-cli version is ${currentVersion}`);
@@ -184,28 +190,36 @@ export class Dependencies {
 
   private isStandaloneCliLatest(callback: (arg0: boolean) => void): void {
     let args = ['--version'];
-    child_process.execFile(this.getStandaloneCliLocation(), args, (error, _stdout, stderr) => {
-      if (!(error != null)) {
-        let currentVersion = _stdout.toString().trim() + stderr.toString().trim();
-        this.logger.debug(`Current wakatime-cli version is ${currentVersion}`);
+    const options = {
+      windowsHide: true,
+    };
+    child_process.execFile(
+      this.getStandaloneCliLocation(),
+      args,
+      options,
+      (error, _stdout, stderr) => {
+        if (!(error != null)) {
+          let currentVersion = _stdout.toString().trim() + stderr.toString().trim();
+          this.logger.debug(`Current wakatime-cli version is ${currentVersion}`);
 
-        this.logger.debug('Checking for updates to wakatime-cli...');
-        this.getLatestStandaloneCliVersion(latestVersion => {
-          if (currentVersion === latestVersion) {
-            this.logger.debug('wakatime-cli is up to date');
-            callback(true);
-          } else if (latestVersion) {
-            this.logger.debug(`Found an updated wakatime-cli v${latestVersion}`);
-            callback(false);
-          } else {
-            this.logger.debug('Unable to find latest wakatime-cli version');
-            callback(false);
-          }
-        });
-      } else {
-        callback(false);
-      }
-    });
+          this.logger.debug('Checking for updates to wakatime-cli...');
+          this.getLatestStandaloneCliVersion(latestVersion => {
+            if (currentVersion === latestVersion) {
+              this.logger.debug('wakatime-cli is up to date');
+              callback(true);
+            } else if (latestVersion) {
+              this.logger.debug(`Found an updated wakatime-cli v${latestVersion}`);
+              callback(false);
+            } else {
+              this.logger.debug('Unable to find latest wakatime-cli version');
+              callback(false);
+            }
+          });
+        } else {
+          callback(false);
+        }
+      },
+    );
   }
 
   private getLatestCliVersion(callback: (arg0: string) => void): void {

--- a/src/wakatime.ts
+++ b/src/wakatime.ts
@@ -355,7 +355,10 @@ export class WakaTime {
 
     const binary = this.standalone || !pythonBinary ? cli : pythonBinary;
     this.logger.debug(`Sending heartbeat: ${this.formatArguments(binary, args)}`);
-    let process = child_process.execFile(binary, args, (error, stdout, stderr) => {
+    const options = {
+      windowsHide: true,
+    };
+    let process = child_process.execFile(binary, args, options, (error, stdout, stderr) => {
       if (error != null) {
         if (stderr && stderr.toString() != '') this.logger.error(stderr.toString());
         if (stdout && stdout.toString() != '') this.logger.error(stdout.toString());
@@ -449,7 +452,10 @@ export class WakaTime {
     this.logger.debug(
       `Fetching coding activity for Today from api: ${this.formatArguments(binary, args)}`,
     );
-    let process = child_process.execFile(binary, args, (error, stdout, stderr) => {
+    const options = {
+      windowsHide: true,
+    };
+    let process = child_process.execFile(binary, args, options, (error, stdout, stderr) => {
       if (error != null) {
         if (stderr && stderr.toString() != '') this.logger.error(stderr.toString());
         if (stdout && stdout.toString() != '') this.logger.error(stdout.toString());


### PR DESCRIPTION
[iam__ceo](https://twitter.com/iam__ceo/status/1312275054416232449) on Twitter says:

> I started using @WakaTime today to help me track my coding progress, but it keeps doing this weird thing whenever I open my vs code.....it opens and closes another window tab repeated and automatically. How do I solve this, is this problem to my PC.?

Fixed by setting `options.windowsHide` to `true` when executing wakatime-cli with [Node.js child_process](https://nodejs.org/api/child_process.html#child_process_child_process_execfile_file_args_options_callback).

Related to:

* wakatime/sublime-wakatime#7
* wakatime/sublime-wakatime#8
* wakatime/sublime-wakatime#12
* wakatime/sublime-wakatime#91
* wakatime/vim-wakatime#52
* wakatime/sublime-wakatime#1