### PR TITLE
Support global WakaTime installation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -252,6 +252,11 @@
                 }
             }
         },
+        "@types/which": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@types/which/-/which-1.3.2.tgz",
+            "integrity": "sha512-8oDqyLC7eD4HM307boe2QWKyuzdzWBj56xI/imSl2cpL+U3tCMaTAkMJ4ee5JBZ/FsOJlvRGeIShiZDAl1qERA=="
+        },
         "@webassemblyjs/ast": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.1.tgz",
@@ -1368,8 +1373,7 @@
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-            "dev": true
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
         },
         "isstream": {
             "version": "0.1.2",
@@ -2608,7 +2612,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-            "dev": true,
             "requires": {
                 "isexe": "^2.0.0"
             }

--- a/package.json
+++ b/package.json
@@ -112,5 +112,9 @@
     "typescript": "^4.1.3",
     "webpack": "^5.11.1",
     "webpack-cli": "^4.3.1"
+  },
+  "dependencies": {
+    "@types/which": "^1.3.2",
+    "which": "^2.0.2"
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -84,8 +84,14 @@ export function activate(ctx: vscode.ExtensionContext) {
     if (debug === 'true') {
       logger.setLevel(LogLevel.DEBUG);
     }
-    options.getSetting('settings', 'standalone', (_err, standalone) => {
-      wakatime.initialize(standalone !== 'false');
+    options.getSetting('settings', 'global', (_err, global) => {
+      const isGlobal = global === 'true';
+      if (isGlobal) wakatime.initialize(isGlobal, false);
+      else {
+        options.getSetting('settings', 'standalone', (_err, standalone) => {
+          wakatime.initialize(false, standalone !== 'false');
+        });
+      }
     });
   });
 }


### PR DESCRIPTION
This is quick-and-dirty for the moment but I'll clean it up if you think it's worth adding as an option. For systems like NixOS ones where the paths are unpredictable, I added a dependency on node-which. This could also replace or be used alongside the current search for python, although the existing method found my python executable fine.

Feel free to flat-out reject this if it goes against what you're aiming for in terms of config surface etc.

Closes #177.