### PR TITLE
Fix grammatical error in status bar tooltip

### DIFF
--- a/src/wakatime.ts
+++ b/src/wakatime.ts
@@ -467,7 +467,7 @@ export class WakaTime {
       if (code == 0) {
         if (output && this.showStatusBar && this.showCodingActivity) {
           this.statusBar.text = `$(clock) ${output}`;
-          this.statusBar.tooltip = `WakaTime: You coded ${output.trim()} today.`;
+          this.statusBar.tooltip = `WakaTime: Today you have spent ${output.trim()}.`;
         }
       } else if (code == 102) {
         if (new_go_cli) {


### PR DESCRIPTION
The current tooltip in the status bar will start with "You coded", resulting in a grammatical error when the output is added which this PR aims to fix.

For example, the message 

> WakaTime: You coded 2 hrs 32 mins Coding, 36 mins Debugging, 25 mins Building today.

will be changed to 

> WakaTime: Today you have spent 2 hrs 32 mins Coding, 36 mins Debugging, 25 mins Building.

**Screenshot of current tooltip:**

![image](https://user-images.githubusercontent.com/47401343/126047637-6d2c68c6-9511-40ed-9eaa-74b1b3a13847.png)

