### PR TITLE
Add `.vscode-test-web` to `.vscodeignore`

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -17,3 +17,4 @@ node_modules/**
 tags
 tags.lock
 tags.temp
+.vscode-test-web


### PR DESCRIPTION
Resolve #292

With this change, the bundle size should be a mere 364K.