### PR TITLE
Add VSCode setting for API key

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,10 +93,13 @@
       }
     ],
     "configuration": {
-      "wakatime.api_key": {
-        "type": "string",
-        "description": "Defaults to value from ~/.wakatime.cfg, unless running in browser.",
-        "scope": "application"
+      "title": "WakaTime",
+      "properties": {
+        "wakatime.apiKey": {
+          "type": "string",
+          "description": "Defaults to value from ~/.wakatime.cfg, unless running in browser.",
+          "scope": "application"
+        }
       }
     }
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,8 @@ var wakatime: WakaTime;
 export function activate(ctx: vscode.ExtensionContext) {
   wakatime = new WakaTime(ctx.extensionPath, logger);
 
+  ctx.globalState?.setKeysForSync(['wakatime.apiKey']);
+
   ctx.subscriptions.push(
     vscode.commands.registerCommand(COMMAND_API_KEY, function () {
       wakatime.promptForApiKey();

--- a/src/options.ts
+++ b/src/options.ts
@@ -204,9 +204,14 @@ export class Options {
   }
 
   public async getApiKeyAsync(): Promise<string> {
-    const key = this.getApiKeyFromEnv();
-    if (!Utils.apiKeyInvalid(key)) {
-      return key;
+    const keyFromSettings = this.getApiKeyFromEditor();
+    if (!Utils.apiKeyInvalid(keyFromSettings)) {
+      return keyFromSettings;
+    }
+
+    const keyFromEnv = this.getApiKeyFromEnv();
+    if (!Utils.apiKeyInvalid(keyFromEnv)) {
+      return keyFromEnv;
     }
 
     if (!Utils.apiKeyInvalid(this.cache.api_key)) {
@@ -280,6 +285,10 @@ export class Options {
         }
         callback(null);
       });
+  }
+
+  private getApiKeyFromEditor(): string {
+    return vscode.workspace.getConfiguration().get('wakatime.apiKey') || '';
   }
 
   // Support for gitpod.io https://github.com/wakatime/vscode-wakatime/pull/220

--- a/src/wakatime.ts
+++ b/src/wakatime.ts
@@ -156,7 +156,6 @@ export class WakaTime {
         if (val != undefined) {
           let invalid = Utils.apiKeyInvalid(val);
           if (!invalid) {
-            vscode.workspace.getConfiguration().update('wakatime.apiKey', val, vscode.ConfigurationTarget.Global);
             this.options.setSetting('settings', 'api_key', val, false);
           } else vscode.window.setStatusBarMessage(invalid);
         } else vscode.window.setStatusBarMessage('WakaTime api key not provided');

--- a/src/wakatime.ts
+++ b/src/wakatime.ts
@@ -156,7 +156,7 @@ export class WakaTime {
         if (val != undefined) {
           let invalid = Utils.apiKeyInvalid(val);
           if (!invalid) {
-            vscode.workspace.getConfiguration().update('wakatime.apiKey', val);
+            vscode.workspace.getConfiguration().update('wakatime.apiKey', val, vscode.ConfigurationTarget.Global);
             this.options.setSetting('settings', 'api_key', val, false);
           } else vscode.window.setStatusBarMessage(invalid);
         } else vscode.window.setStatusBarMessage('WakaTime api key not provided');

--- a/src/wakatime.ts
+++ b/src/wakatime.ts
@@ -142,13 +142,12 @@ export class WakaTime {
   }
 
   public promptForApiKey(): void {
-    this.options.getSetting('settings', 'api_key', false, (setting: Setting) => {
-      let defaultVal = setting.value;
-      if (Utils.apiKeyInvalid(defaultVal)) defaultVal = '';
+    this.options.getApiKey((defaultVal: string | null) => {
+      if (Utils.apiKeyInvalid(defaultVal ?? undefined)) defaultVal = '';
       let promptOptions = {
         prompt: 'WakaTime Api Key',
         placeHolder: 'Enter your api key from https://wakatime.com/settings',
-        value: defaultVal,
+        value: defaultVal!,
         ignoreFocusOut: true,
         password: true,
         validateInput: Utils.apiKeyInvalid.bind(this),
@@ -156,8 +155,10 @@ export class WakaTime {
       vscode.window.showInputBox(promptOptions).then((val) => {
         if (val != undefined) {
           let invalid = Utils.apiKeyInvalid(val);
-          if (!invalid) this.options.setSetting('settings', 'api_key', val, false);
-          else vscode.window.setStatusBarMessage(invalid);
+          if (!invalid) {
+            vscode.workspace.getConfiguration().update('wakatime.apiKey', val);
+            this.options.setSetting('settings', 'api_key', val, false);
+          } else vscode.window.setStatusBarMessage(invalid);
         } else vscode.window.setStatusBarMessage('WakaTime api key not provided');
       });
     });

--- a/src/web/extension.ts
+++ b/src/web/extension.ts
@@ -18,6 +18,8 @@ var wakatime: WakaTime;
 export function activate(ctx: vscode.ExtensionContext) {
   wakatime = new WakaTime(logger, ctx.globalState);
 
+  ctx.globalState?.setKeysForSync(['wakatime.apiKey']);
+
   ctx.subscriptions.push(
     vscode.commands.registerCommand(COMMAND_API_KEY, function () {
       wakatime.promptForApiKey();

--- a/src/web/wakatime.ts
+++ b/src/web/wakatime.ts
@@ -110,7 +110,7 @@ export class WakaTime {
   }
 
   public promptForApiKey(): void {
-    let defaultVal: string = this.config.get('wakatime.api_key') || '';
+    let defaultVal: string = this.config.get('wakatime.apiKey') || '';
     if (Utils.apiKeyInvalid(defaultVal)) defaultVal = '';
     let promptOptions = {
       prompt: 'WakaTime Api Key',
@@ -122,7 +122,7 @@ export class WakaTime {
     vscode.window.showInputBox(promptOptions).then((val) => {
       if (val != undefined) {
         let invalid = Utils.apiKeyInvalid(val);
-        if (!invalid) this.config.update('wakatime.api_key', val);
+        if (!invalid) this.config.update('wakatime.apiKey', val);
         else vscode.window.setStatusBarMessage(invalid);
       } else vscode.window.setStatusBarMessage('WakaTime api key not provided');
     });
@@ -230,7 +230,7 @@ export class WakaTime {
   }
 
   private hasApiKey(callback: (arg0: boolean) => void): void {
-    const apiKey: string = this.config.get('wakatime.api_key') || '';
+    const apiKey: string = this.config.get('wakatime.apiKey') || '';
     callback(!Utils.apiKeyInvalid(apiKey));
   }
 
@@ -365,7 +365,7 @@ export class WakaTime {
 
     this.logger.debug(`Sending heartbeat: ${JSON.stringify(payload)}`);
 
-    const apiKey = this.config.get('wakatime.api_key');
+    const apiKey = this.config.get('wakatime.apiKey');
     const url = `https://api.wakatime.com/api/v1/users/current/heartbeats?api_key=${apiKey}`;
 
     try {
@@ -437,7 +437,7 @@ export class WakaTime {
 
   private async _getCodingActivity() {
     this.logger.debug('Fetching coding activity for Today from api.');
-    const apiKey = this.config.get('wakatime.api_key');
+    const apiKey = this.config.get('wakatime.apiKey');
     const url = `https://api.wakatime.com/api/v1/users/current/statusbar/today?api_key=${apiKey}`;
     try {
       const response = await fetch(url, {


### PR DESCRIPTION
Resolves #283.
I was not able to test it for the VSCode Web extension, but in theory it should work.

Here's what it looks like:
![image](https://user-images.githubusercontent.com/33439542/211218461-aa2d1049-3add-4dc1-9639-25961c55dd13.png)
![image](https://user-images.githubusercontent.com/33439542/211218470-dd9d8921-d0a3-4c40-bf28-895b363bf98c.png)

Now setting the API key from the prompt (`WakaTime: Api Key` command) will also set it in VSCode global settings. Let me know if this should not be the case.
VSCode Settings Sync is also enabled for the API key.