### PR TITLE
Resolve api_key_vault_cmd like wakatime-cli does

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -239,11 +239,21 @@ export class Options {
 
   public async getApiKeyFromVaultCmd(): Promise<string> {
     try {
-      const apiKeyCmd = await this.getSettingAsync<string>('settings', 'api_key_vault_cmd');
-      if (!apiKeyCmd) return '';
+      // Use basically the same logic as wakatime-cli to interpret cmdStr
+      // https://github.com/wakatime/wakatime-cli/blob/1fd560a/cmd/params/params.go#L697
+      let cmdStr = await this.getSettingAsync<string>('settings', 'api_key_vault_cmd');
+      if (!cmdStr) return '';
+
+      cmdStr = cmdStr.trim();
+      if (cmdStr === '') return '';
+
+      const cmdParts = cmdStr.split(" ");
+      if (cmdParts.length === 0) return '';
+
+      const [cmdName, ...cmdArgs] = cmdParts;
 
       const options = Desktop.buildOptions();
-      const proc = child_process.spawn(apiKeyCmd, options);
+      const proc = child_process.spawn(cmdName, cmdArgs, options);
 
       let stdout = '';
       for await (const chunk of proc.stdout) {


### PR DESCRIPTION
This package was treating the entire config value of `api_key_vault_cmd` as one executable name, rather than treating it as a shell command --- but it also probably shouldn't treat it as a shell command, as wakatime-cli doesn't do that either.

wakatime-cli instead treats the value as a space-separated list of the executable and its arguments:

https://github.com/wakatime/wakatime-cli/blob/1fd560a/cmd/params/params.go#L707-L719

This PR makes vscode-wakatime mimick that behavior.

This should fix https://github.com/wakatime/vscode-wakatime/issues/387.