### PR TITLE
refactor: Prioritize using api_url to open dashboard

### DIFF
--- a/src/wakatime.ts
+++ b/src/wakatime.ts
@@ -363,8 +363,19 @@ export class WakaTime {
   }
 
   public openDashboardWebsite(): void {
-    let url = 'https://wakatime.com/';
-    vscode.env.openExternal(vscode.Uri.parse(url));
+    this.options.getSetting('settings', 'api_url', false, (apiUrl: Setting) => {
+      let url = 'https://wakatime.com/';
+      if (apiUrl.value !== undefined) {
+        try {
+          const parsedUrl = new URL(apiUrl.value);
+          url = `${parsedUrl.protocol}//${parsedUrl.hostname}${parsedUrl.port ? `:${parsedUrl.port}` : ''}`;
+        } catch (e) {
+          this.logger.warnException(e);
+        }
+        console.log(url)
+      }
+      vscode.env.openExternal(vscode.Uri.parse(url));
+    })
   }
 
   public openConfigFile(): void {

--- a/src/wakatime.ts
+++ b/src/wakatime.ts
@@ -365,17 +365,16 @@ export class WakaTime {
   public openDashboardWebsite(): void {
     this.options.getSetting('settings', 'api_url', false, (apiUrl: Setting) => {
       let url = 'https://wakatime.com/';
-      if (apiUrl.value !== undefined) {
+      if (apiUrl.value?.trim()) {
         try {
           const parsedUrl = new URL(apiUrl.value);
           url = `${parsedUrl.protocol}//${parsedUrl.hostname}${parsedUrl.port ? `:${parsedUrl.port}` : ''}`;
         } catch (e) {
           this.logger.warnException(e);
         }
-        console.log(url)
       }
       vscode.env.openExternal(vscode.Uri.parse(url));
-    })
+    });
   }
 
   public openConfigFile(): void {


### PR DESCRIPTION
Allow opening the local WakaTime dashboard when the user clicks the status button. 
Refactor openDashboardWebsite function to prioritize `api_url` setting.