### PR TITLE
Fix `open-in-browser` NPM script

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "compile": "webpack --mode none",
     "compile:dev": "tsc -p ./",
     "watch": "webpack --mode none --watch",
-    "open-in-browser": "vscode-test-web --open-devtools --version sources --extensionDevelopmentPath=. .",
+    "open-in-browser": "vscode-test-web --open-devtools --quality insiders --extensionDevelopmentPath=. .",
     "test": "npm run compile:dev && node ./node_modules/vscode/bin/test"
   },
   "contributes": {


### PR DESCRIPTION
### Context

If you freshly clone the repo and attempt to run the web version with `npm run open-in-browser`, you currently get an error:

```
@vscode/test-web: 0.0.22
--version has been replaced by --quality
Instead of version=sources use 'sourcesPath' with the location of the VS Code repository.
```

This is because the `vscode-test-web` tool replaced the `--version` argument with a `--quality` argument in v0.0.16 (released January 2022). Take a look at the commit that made the change for more details: https://github.com/microsoft/vscode-test-web/commit/55977b807acf063bd1fd1014689724067b54e01a

### This pull request

This PR brings the syntax used in our NPM script into line with the change made by `vscode-test-web`, which means that the `open-in-browser` script now works.

One small warning: if someone developing this extension still happen to have an old (pre-0.0.16) version of `@vscode/test-web` installed, then this PR will break the script for them, and they'll have to bring their dependencies up-to-date with the versions specified in our `package.json` (i.e. run `npm install).
