### PR TITLE
Open dashboard messes up the url

### DIFF
--- a/src/wakatime.ts
+++ b/src/wakatime.ts
@@ -145,7 +145,7 @@ export class WakaTime {
           this.setStatusBarVisibility(this.showStatusBar);
           this.updateStatusBarText('WakaTime Initializing...');
 
-          this.checkKey();
+          this.checkApiKey();
 
           this.setupEventListeners();
 
@@ -217,22 +217,22 @@ export class WakaTime {
     this.statusBarTeamOther.tooltip = tooltipText;
   }
 
-  public async promptForKey(hidden: boolean = true): Promise<void> {
-    let defaultVal = await this.options.getKey();
-    if (Utils.KeyInvalid(defaultVal ?? undefined)) defaultVal = '';
+  public async promptForApiKey(hidden: boolean = true): Promise<void> {
+    let defaultVal = await this.options.getApiKey();
+    if (Utils.apiKeyInvalid(defaultVal ?? undefined)) defaultVal = '';
     let promptOptions = {
-      prompt: 'WakaTime  Key',
-      placeHolder: 'Enter your  key from https://wakatime.com/-key',
+      prompt: 'WakaTime Api Key',
+      placeHolder: 'Enter your api key from https://wakatime.com/api-key',
       value: defaultVal!,
       ignoreFocusOut: true,
       password: hidden,
-      validateInput: Utils.KeyInvalid.bind(this),
+      validateInput: Utils.apiKeyInvalid.bind(this),
     };
     vscode.window.showInputBox(promptOptions).then((val) => {
       if (val != undefined) {
-        let invalid = Utils.KeyInvalid(val);
+        let invalid = Utils.apiKeyInvalid(val);
         if (!invalid) {
-          this.options.setSetting('settings', '_key', val, false);
+          this.options.setSetting('settings', 'api_key', val, false);
         } else vscode.window.setStatusBarMessage(invalid);
       } else vscode.window.setStatusBarMessage('WakaTime api key not provided');
     });

--- a/src/wakatime.ts
+++ b/src/wakatime.ts
@@ -369,7 +369,8 @@ export class WakaTime {
   }
 
   public async openDashboardWebsite(): Promise<void> {
-    const url = (await this.options.getApiUrl(true)).replace('/api/v1', '').replace('api.', '');
+    const apiUrl = vscode.Uri.parse(await this.options.getApiUrl(true));
+    const url = `${apiUrl.scheme}://${apiUrl.authority.replace(/^api\./, '')}`;
     vscode.env.openExternal(vscode.Uri.parse(url));
   }
 

--- a/src/wakatime.ts
+++ b/src/wakatime.ts
@@ -145,7 +145,7 @@ export class WakaTime {
           this.setStatusBarVisibility(this.showStatusBar);
           this.updateStatusBarText('WakaTime Initializing...');
 
-          this.checkApiKey();
+          this.checkKey();
 
           this.setupEventListeners();
 
@@ -217,22 +217,22 @@ export class WakaTime {
     this.statusBarTeamOther.tooltip = tooltipText;
   }
 
-  public async promptForApiKey(hidden: boolean = true): Promise<void> {
-    let defaultVal = await this.options.getApiKey();
-    if (Utils.apiKeyInvalid(defaultVal ?? undefined)) defaultVal = '';
+  public async promptForKey(hidden: boolean = true): Promise<void> {
+    let defaultVal = await this.options.getKey();
+    if (Utils.KeyInvalid(defaultVal ?? undefined)) defaultVal = '';
     let promptOptions = {
-      prompt: 'WakaTime Api Key',
-      placeHolder: 'Enter your api key from https://wakatime.com/api-key',
+      prompt: 'WakaTime  Key',
+      placeHolder: 'Enter your  key from https://wakatime.com/-key',
       value: defaultVal!,
       ignoreFocusOut: true,
       password: hidden,
-      validateInput: Utils.apiKeyInvalid.bind(this),
+      validateInput: Utils.KeyInvalid.bind(this),
     };
     vscode.window.showInputBox(promptOptions).then((val) => {
       if (val != undefined) {
-        let invalid = Utils.apiKeyInvalid(val);
+        let invalid = Utils.KeyInvalid(val);
         if (!invalid) {
-          this.options.setSetting('settings', 'api_key', val, false);
+          this.options.setSetting('settings', '_key', val, false);
         } else vscode.window.setStatusBarMessage(invalid);
       } else vscode.window.setStatusBarMessage('WakaTime api key not provided');
     });
@@ -369,8 +369,7 @@ export class WakaTime {
   }
 
   public async openDashboardWebsite(): Promise<void> {
-    const apiUrl = vscode.Uri.parse(await this.options.getApiUrl(true));
-    const url = `${apiUrl.scheme}://${apiUrl.authority.replace(/^api\./, '')}`;
+    const url = (await this.options.getApiUrl(true)).replace('/api/v1', '').replace('://api.', '://');
     vscode.env.openExternal(vscode.Uri.parse(url));
   }
 


### PR DESCRIPTION
When using a custom `api_url` containing `api.` in the middle, open dashboard removes it and points to a whole new domain.

For example : `https://wakapi.dev/api` is transformed into `https://wak.dev/api` instead of `https://wakapi.dev`.

With this PR, only the deepest subdomain is removed if it is strictly equal to `api` and the path isn't preserved.