### PR TITLE
remove /api path when opening dashboard

### DIFF
--- a/src/wakatime.ts
+++ b/src/wakatime.ts
@@ -371,6 +371,7 @@ export class WakaTime {
   public async openDashboardWebsite(): Promise<void> {
     const url = (await this.options.getApiUrl(true))
       .replace('/api/v1', '')
+      .replace('/api', '')
       .replace('://api.', '://');
     vscode.env.openExternal(vscode.Uri.parse(url));
   }

--- a/src/web/wakatime.ts
+++ b/src/web/wakatime.ts
@@ -295,7 +295,7 @@ export class WakaTime {
   }
 
   public openDashboardWebsite(): void {
-    const url = this.getApiUrl().replace('/api/v1', '').replace('://api.', '://');
+    const url = this.getApiUrl().replace('/api/v1', '').replace('/api', '').replace('://api.', '://');
     vscode.env.openExternal(vscode.Uri.parse(url));
   }
 


### PR DESCRIPTION
- Background
  - when using open soured self-host version of wakatime like [wakapi](https://github.com/muety/wakapi), the end point of base url is "/api", which is not be removed when accessing the dashboard. It leads to the 404 page of dashboard.
- This PR:
  - Ensures clicking status bar icon opens dashboard instead of 404 page, when using self-host platform like wakapi
  - Fixed in both desktop and web versions

