### PR TITLE
Fix overwriting config file

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -248,6 +248,7 @@ export class Options {
           vscode.window.showErrorMessage(
             `WakaTime API Key conflict. Your ~/.wakatime.cfg key doesn't match your ${from} key.`,
           );
+          return this.cache.api_key;
         }
         this.cache.api_key = apiKey;
       }


### PR DESCRIPTION
In src/options.ts, the getApiKey() method had inconsistent conflict handling across different API key sources:

✅ ENV conflicts: Show error → Return cached key (early return) ✅ Vault conflicts: Show error → Return cached key (early return) ❌ Config file conflicts: Show error → Continue and overwrite cache The config file conflict handling was missing the early return statement that other conflict types had.