### PR TITLE
Track time for writing tests based on filename patterns

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -30,7 +30,7 @@ export interface Heartbeat {
   project_folder?: string;
   project_root_count?: number;
   language?: string;
-  category?: 'debugging' | 'ai coding' | 'building' | 'code reviewing';
+  category?: 'debugging' | 'ai coding' | 'building' | 'code reviewing' | 'writing tests';
   ai_line_changes?: number;
   human_line_changes?: number;
   is_unsaved_entity?: boolean;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -173,6 +173,43 @@ export class Utils {
       return vscode.env.appName.replace(/\s/g, '').toLowerCase();
     }
   }
+
+  public static isTestFile(fileName: string): boolean {
+    const testPatterns = [
+      // Common patterns for test files, can easily be extended later in case I forgot any
+      '.test.',
+      '.tests.',
+      'test.',
+      'tests.',
+      '.spec.',
+      '.specs.',
+      'spec.',
+      'specs.',
+      '.check.',
+      'check.',
+      '.unit.',
+      'unit.',
+      '.integration.',
+      'integration.',
+      '.e2e.',
+      'e2e.',
+      'test_',
+      'tests_',
+      'spec_',
+      'specs_',
+      '_test.',
+      '_tests.',
+      '_spec.',
+      '_specs.',
+      '_check.',
+      '_unit.',
+      '_integration.',
+      '_e2e.',
+    ];
+
+    const fileNameLowercase = fileName.toLowerCase();
+    return testPatterns.some((pattern) => fileNameLowercase.includes(pattern));
+  }
 }
 
 interface FileSelection {

--- a/src/wakatime.ts
+++ b/src/wakatime.ts
@@ -644,6 +644,8 @@ export class WakaTime {
       heartbeat.category = 'ai coding';
     } else if (Utils.isPullRequest(doc.uri)) {
       heartbeat.category = 'code reviewing';
+    } else if (Utils.isTestFile(doc.fileName)) {
+      heartbeat.category = 'writing tests';
     }
 
     const project = this.getProjectName(doc.uri);

--- a/src/web/wakatime.ts
+++ b/src/web/wakatime.ts
@@ -549,6 +549,8 @@ export class WakaTime {
       heartbeat.category = 'ai coding';
     } else if (Utils.isPullRequest(doc.uri)) {
       heartbeat.category = 'code reviewing';
+    } else if (Utils.isTestFile(doc.fileName)) {
+      heartbeat.category = 'writing tests';
     }
 
     if (heartbeat.ai_line_changes) {


### PR DESCRIPTION
This PR adds the ability for wakatime-vscode to track the time spent on writing tests based on common test file name patterns.
The IntelliJ extension tracks time writing tests as well but I have noticed that the VSCode extension does not, so I added it.

**Some Details**
- Wakatime now checks if the filename includes any common test patterns e.g: *\.test.\*, *Test.\*, *\.test.\* etc. (check the isTestFile method in Utils for all patterns)
- The pattern check converts the filename to lowercase first to support files such as *\.tEsT.\*
- No other changes were made to the extension so everything should still work just as before just with the addition of test time being tracked

**How to test**
- Just open a file that matches the test pattern (e.g examplefile.test.ts), make edits and save it, the wakatime status bar should update to reflect the testing time at some point confirming that it works as intended
- Additionally you can check the wakatime extension logs, I did this to confirm the data got sent properly

If there are any changes that need to be made feel free to let me know and I'll apply them