### PR TITLE
feat: add settings for experimental ai detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,6 +124,11 @@
           "type": "string",
           "description": "Defaults to https://api.wakatime.com/api/v1.",
           "scope": "application"
+        },
+        "wakatime.experimentalAIDetection": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable experimental AI detection on copy pasting from unknown sources. Using Copilot chat will always count as AI"
         }
       }
     }

--- a/src/options.ts
+++ b/src/options.ts
@@ -309,6 +309,12 @@ export class Options {
     return vscode.workspace.getConfiguration().get('wakatime.apiUrl') || '';
   }
 
+  public isExperimentalAIDetectionEnabled(): boolean {
+    return (
+      vscode.workspace.getConfiguration().get<boolean>('wakatime.experimentalAIDetection') ?? true
+    );
+  }
+
   // Support for gitpod.io https://github.com/wakatime/vscode-wakatime/pull/220
   public getApiKeyFromEnv(): string {
     if (this.cache.api_key_from_env !== undefined) return this.cache.api_key_from_env;

--- a/src/wakatime.ts
+++ b/src/wakatime.ts
@@ -482,17 +482,20 @@ export class WakaTime {
   }
 
   private onChangeTextDocument(e: vscode.TextDocumentChangeEvent): void {
+    const experimentalAIDetectionEnabled = this.options.isExperimentalAIDetectionEnabled();
+
+
     if (Utils.isAIChatSidebar(e.document?.uri)) {
       this.isAICodeGenerating = true;
       this.AIdebounceCount = 0;
-    } else if (Utils.isPossibleAICodeInsert(e)) {
+    } else if (experimentalAIDetectionEnabled && Utils.isPossibleAICodeInsert(e)) {
       const now = Date.now();
       if (this.recentlyAIPasted(now)) {
         this.isAICodeGenerating = true;
         this.AIdebounceCount = 0;
       }
       this.AIrecentPastes.push(now);
-    } else if (Utils.isPossibleHumanCodeInsert(e)) {
+    } else if (!experimentalAIDetectionEnabled || Utils.isPossibleHumanCodeInsert(e)) {
       this.AIrecentPastes = [];
       if (this.isAICodeGenerating) {
         this.AIdebounceCount++;

--- a/src/web/wakatime.ts
+++ b/src/web/wakatime.ts
@@ -394,17 +394,19 @@ export class WakaTime {
   }
 
   private onChangeTextDocument(e: vscode.TextDocumentChangeEvent): void {
+    const experimentalAIDetectionEnabled = this.isExperimentalAIDetectionEnabled();
+
     if (Utils.isAIChatSidebar(e.document?.uri)) {
       this.isAICodeGenerating = true;
       this.AIdebounceCount = 0;
-    } else if (Utils.isPossibleAICodeInsert(e)) {
+    } else if (experimentalAIDetectionEnabled && Utils.isPossibleAICodeInsert(e)) {
       const now = Date.now();
       if (this.recentlyAIPasted(now)) {
         this.isAICodeGenerating = true;
         this.AIdebounceCount = 0;
       }
       this.AIrecentPastes.push(now);
-    } else if (Utils.isPossibleHumanCodeInsert(e)) {
+    } else if (!experimentalAIDetectionEnabled || Utils.isPossibleHumanCodeInsert(e)) {
       this.AIrecentPastes = [];
       if (this.isAICodeGenerating) {
         this.AIdebounceCount++;
@@ -929,6 +931,12 @@ export class WakaTime {
       return platform;
     }
     return null;
+  }
+
+  private isExperimentalAIDetectionEnabled(): boolean {
+    return (
+      vscode.workspace.getConfiguration().get<boolean>('wakatime.experimentalAIDetection') ?? true
+    );
   }
 
   private getApiUrl(): string {


### PR DESCRIPTION
As said in https://github.com/wakatime/vscode-wakatime/issues/440#issuecomment-3215576032 I find it a good idea, to make the AI detection, that is only a guess, a setting, so that the user can disable it, if he wants to.

The settings is true by default, so no change there, but you have a choice as user.


Feel free to correct my code, ask any question or discard my proposal  😄 