### PR TITLE
Fix typing heartbeat regression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-wakatime",
-  "version": "28.0.2",
+  "version": "28.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-wakatime",
-      "version": "28.0.2",
+      "version": "28.0.3",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@types/adm-zip": "^0.5.7",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-wakatime",
   "displayName": "WakaTime",
   "description": "Metrics, insights, and time tracking automatically generated from your programming activity.",
-  "version": "28.0.2",
+  "version": "28.0.3",
   "publisher": "WakaTime",
   "author": {
     "name": "WakaTime"

--- a/src/wakatime.ts
+++ b/src/wakatime.ts
@@ -558,7 +558,7 @@ export class WakaTime {
   }
 
   private onChangeSelection(e: vscode.TextEditorSelectionChangeEvent): void {
-    if (!ALLOWED_SCHEMES.includes((e as any).document?.uri?.scheme)) return;
+    if (!ALLOWED_SCHEMES.includes(e.textEditor?.document?.uri?.scheme)) return;
     if (e.kind === vscode.TextEditorSelectionChangeKind.Command) return;
     this.logger.debug('onChangeSelection');
     if (Utils.isAIChatSidebar(e.textEditor?.document?.uri)) {


### PR DESCRIPTION
Closes #477. On `TextEditorSelectionChangeEvent`, `e.document` does not exist, unlike other events (see https://vshaxe.github.io/vscode-extern/vscode/TextEditorSelectionChangeEvent.html). The `(e as any)` was masking the fact that this didn't exist. And because of the `?` symbols, this meant that the check would _always_ be falsy, so we'd always be returning.

```
❯ let e = { textEditor: { document: { uri: { scheme: "https" } } } }
{
  textEditor: {
    document: {
      uri: {
        scheme: "https",
      },
    },
  },
}
❯ let scheme = e.document?.uri?.scheme
undefined
```