### PR TITLE
Fix Cursor editor attribution and AI line changes

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { COMMON_AI_EXTENSIONS, TIME_BETWEEN_HEARTBEATS_MS } from './constants';
 
 export class Utils {
-  private static appNames = {
+  private static appNames: { [key: string]: string } = {
     'Arduino IDE': 'arduino',
     'Azure Data Studio': 'azdata',
     Cursor: 'cursor',
@@ -14,6 +14,18 @@ export class Utils {
     Trae: 'trae',
     Windsurf: 'windsurf',
   };
+
+  private static aiCapableEditors = new Set(['cursor', 'kiro', 'qoder', 'trae', 'windsurf']);
+
+  private static editorNameFromHint(hint?: string): string | undefined {
+    const normalized = hint?.replace(/\s/g, '').toLowerCase();
+    if (!normalized) return undefined;
+
+    for (const editor of Object.keys(this.appNames)) {
+      const editorKey = editor.replace(/\s/g, '').toLowerCase();
+      if (normalized.includes(editorKey)) return this.appNames[editor];
+    }
+  }
 
   public static quote(str: string): string {
     if (str.includes(' ')) return `"${str.replace(/"/g, '\\"')}"`;
@@ -199,23 +211,29 @@ export class Utils {
     return false;
   }
 
-  public static getEditorName(): string {
-    if (this.appNames[vscode.env.appName]) {
-      return this.appNames[vscode.env.appName];
+  public static getEditorName(env: typeof vscode.env = vscode.env): string {
+    if (this.appNames[env.appName]) {
+      return this.appNames[env.appName];
     }
 
-    const appRoot = vscode.env.appRoot.toLowerCase();
-    for (const editor of Object.keys(this.appNames)) {
-      if (appRoot.includes(editor.toLowerCase())) {
-        return this.appNames[editor];
-      }
+    const editorName = this.editorNameFromHint(env.uriScheme) || this.editorNameFromHint(env.appRoot);
+    if (editorName) {
+      return editorName;
     }
 
-    if (vscode.env.appName.toLowerCase().includes('visual')) {
+    if (env.appName.toLowerCase().includes('visual')) {
       return 'vscode';
     } else {
-      return vscode.env.appName.replace(/\s/g, '').toLowerCase();
+      return env.appName.replace(/\s/g, '').toLowerCase();
     }
+  }
+
+  public static isAICapableEditor(editorName: string = this.getEditorName()): boolean {
+    return this.aiCapableEditors.has(editorName);
+  }
+
+  public static hasAICapabilities(editorName: string = this.getEditorName()): boolean {
+    return this.isAICapableEditor(editorName) || this.hasAIExtensions();
   }
 
   public static hasAIExtensions(): boolean {

--- a/src/wakatime.ts
+++ b/src/wakatime.ts
@@ -92,7 +92,7 @@ export class WakaTime {
         this.extension = (extension != undefined && extension.packageJSON) || { version: '0.0.0' };
         this.editorName = Utils.getEditorName();
 
-        this.hasAICapabilities = Utils.hasAIExtensions();
+        this.hasAICapabilities = Utils.hasAICapabilities(this.editorName);
 
         this.options.getSetting('settings', 'disabled', false, (disabled: Setting) => {
           this.disabled = disabled.value === 'true';
@@ -552,9 +552,13 @@ export class WakaTime {
       this.AIdebounceCount = 0;
     } else if (Utils.isPossibleAICodeInsert(e)) {
       const now = Date.now();
-      if (this.recentlyAIPasted(now) && this.hasAICapabilities) {
+      if (
+        this.hasAICapabilities &&
+        (Utils.isAICapableEditor(this.editorName) || this.recentlyAIPasted(now))
+      ) {
         this.isAICodeGenerating = true;
         this.AIdebounceCount = 0;
+        this.updateLineNumbersFromChange(e);
       }
       this.AIrecentPastes.push(now);
     } else if (Utils.isPossibleHumanCodeInsert(e)) {
@@ -577,6 +581,23 @@ export class WakaTime {
     if (!this.isAICodeGenerating) return;
 
     this.onEvent(false);
+  }
+
+  private updateLineNumbersFromChange(e: vscode.TextDocumentChangeEvent): void {
+    const file = Utils.getFocusedFile(e.document);
+    if (!file) return;
+
+    const now = Date.now();
+    let delta = 0;
+    for (const change of e.contentChanges) {
+      const newLineBreaks = (change.text.match(/\r\n|\r|\n/g) || []).length;
+      const replacedLineBreaks = change.range.end.line - change.range.start.line;
+      delta += newLineBreaks - replacedLineBreaks;
+    }
+
+    const changes = this.isAICodeGenerating ? this.lineChanges.ai : this.lineChanges.human;
+    changes[file] = (changes[file] ?? 0) + delta;
+    this.linesInFiles[file] = { lines: e.document.lineCount, updatedAt: now };
   }
 
   private onChangeTab(e: vscode.TextEditor | undefined): void {

--- a/src/web/wakatime.ts
+++ b/src/web/wakatime.ts
@@ -69,7 +69,7 @@ export class WakaTime {
     this.extension = (extension != undefined && extension.packageJSON) || { version: '0.0.0' };
     this.agentName = Utils.getEditorName();
 
-    this.hasAICapabilities = Utils.hasAIExtensions();
+    this.hasAICapabilities = Utils.hasAICapabilities(this.agentName);
 
     this.disabled = this.config.get('wakatime.disabled') === 'true';
     if (this.disabled) {


### PR DESCRIPTION
## Summary
- detect Cursor from URI scheme/app root before falling back to VS Code naming
- treat Cursor and other built-in AI editor forks as AI-capable without requiring a separate AI extension
- count net line changes immediately for large AI-like document changes in built-in AI editors so Cursor edits can report `ai_line_changes` when transcript metadata lacks edit content

## Verification
- `npm run compile:dev`
- `npm run compile`

## Notes
- `npm test` currently fails before running tests because `node_modules/vscode/bin/test` is missing from the installed `vscode` package.

Fixes #483